### PR TITLE
after:deploy:deploy hook never finishes

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,8 @@ class AWSOAuthScopes {
   constructor(serverless, options) {
     this.options = options;
     this.hooks = {
-      'after:deploy:deploy': function () {
-        setOAuthScopes(serverless);
+      'after:deploy:deploy': async function () {
+        await setOAuthScopes(serverless);
       }
     };
   }


### PR DESCRIPTION
The process exits without waiting for the promise to complete. Needs to wait for this promise to complete.